### PR TITLE
Added 'Ignore Keys' parameter to remove unwanted fields from exported template.

### DIFF
--- a/cicd-utils/info.json
+++ b/cicd-utils/info.json
@@ -140,7 +140,7 @@
       "description": "Export updated FortiSOAR Template's zip file.",
       "output_schema": {
         "file_iri": ""
-    },
+      },
       "parameters": [
         {
           "title": "Export Template Name",
@@ -161,6 +161,99 @@
           "editable": true,
           "description": "Specify the export file name to retrieve export templates.",
           "tooltip": "Specify the export file name to retrieve export templates."
+        },
+        {
+          "title": "Ignore Keys",
+          "type": "json",
+          "name": "ignore_keys",
+          "required": false,
+          "visible": true,
+          "editable": true,
+          "value": [
+            {
+              "file_path": "/info.json",
+              "operations": [
+                {
+                  "key_path": "contents.globalVariables",
+                  "key_type": "list",
+                  "key_to_compare": "name",
+                  "values_to_remove": [
+                    "Default_Email",
+                    "Server_fqhn"
+                  ]
+                },
+                {
+                  "key_path": "",
+                  "key_type": "dict",
+                  "keys_to_remove": [
+                    "exported_from",
+                    "date"
+                  ]
+                }
+              ]
+            },
+            {
+              "file_path": "/playbooks/globalVariables.json",
+              "operations": [
+                {
+                  "key_path": "",
+                  "key_type": "list",
+                  "key_to_compare": "name",
+                  "values_to_remove": [
+                    "Default_Email",
+                    "Server_fqhn"
+                  ]
+                }
+              ]
+            },
+            {
+              "file_path": "/records/export_templates/Source Control - Production Content.json",
+              "operations": [
+                {
+                  "key_path": "",
+                  "key_type": "dict",
+                  "keys_to_remove": [
+                    "modifyDate",
+                    "modifyUser",
+                    "id",
+                    "lastExportDate"
+                  ]
+                }
+              ]
+            },
+            {
+              "file_path": "/records/export_templates/Source Control - Development Settings.json",
+              "operations": [
+                {
+                  "key_path": "",
+                  "key_type": "dict",
+                  "keys_to_remove": [
+                    "modifyDate",
+                    "modifyUser",
+                    "id",
+                    "lastExportDate"
+                  ]
+                }
+              ]
+            },
+            {
+              "file_path": "/records/export_templates/Source Control - Production Settings.json",
+              "operations": [
+                {
+                  "key_path": "",
+                  "key_type": "dict",
+                  "keys_to_remove": [
+                    "modifyDate",
+                    "modifyUser",
+                    "id",
+                    "lastExportDate"
+                  ]
+                }
+              ]
+            }
+          ],
+          "description": "Specify the key's details which are to be removed from specified files. For example: [\n    {\n        \"file_path\": \"/info.json\",\n        \"operations\": [\n            {\n                \"key_path\": \"contents.globalVariables\",\n                \"key_type\": \"list\",\n                \"key_to_compare\": \"name\",\n                \"values_to_remove\": [\"Default_Email\", \"Server_fqhn\"]\n            },\n            {\n                \"key_path\": \"\",\n                \"key_type\": \"dict\",\n                \"keys_to_remove\": [\"exported_from\", \"date\"]\n            }\n\n        ]\n    }]",
+          "tooltip": "Specify the key's details which are to be removed from specified files. For more information, see connector documentation."
         }
       ],
       "enabled": true

--- a/cicd-utils/playbooks/playbooks.json
+++ b/cicd-utils/playbooks/playbooks.json
@@ -189,7 +189,90 @@
                 "config": "''",
                 "params": {
                   "export_template_name": "",
-                  "export_file_name": ""
+                  "export_file_name": "",
+                  "remove_keys_from": [
+                    {
+                      "file_path": "/info.json",
+                      "operations": [
+                        {
+                          "key_path": "contents.globalVariables",
+                          "key_type": "list",
+                          "key_to_compare": "name",
+                          "values_to_remove": [
+                            "Default_Email",
+                            "Server_fqhn"
+                          ]
+                        },
+                        {
+                          "key_path": "",
+                          "key_type": "dict",
+                          "keys_to_remove": [
+                            "exported_from",
+                            "date"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "file_path": "/playbooks/globalVariables.json",
+                      "operations": [
+                        {
+                          "key_path": "",
+                          "key_type": "list",
+                          "key_to_compare": "name",
+                          "values_to_remove": [
+                            "Default_Email",
+                            "Server_fqhn"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "file_path": "/records/export_templates/Source Control - Production Content.json",
+                      "operations": [
+                        {
+                          "key_path": "",
+                          "key_type": "dict",
+                          "keys_to_remove": [
+                            "modifyDate",
+                            "modifyUser",
+                            "id",
+                            "lastExportDate"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "file_path": "/records/export_templates/Source Control - Development Settings.json",
+                      "operations": [
+                        {
+                          "key_path": "",
+                          "key_type": "dict",
+                          "keys_to_remove": [
+                            "modifyDate",
+                            "modifyUser",
+                            "id",
+                            "lastExportDate"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "file_path": "/records/export_templates/Source Control - Production Settings.json",
+                      "operations": [
+                        {
+                          "key_path": "",
+                          "key_type": "dict",
+                          "keys_to_remove": [
+                            "modifyDate",
+                            "modifyUser",
+                            "id",
+                            "lastExportDate"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
                 },
                 "version": "1.1.0",
                 "connector": "cicd-utils",

--- a/cicd-utils/release_notes.md
+++ b/cicd-utils/release_notes.md
@@ -1,4 +1,4 @@
 #### What's Improved
 - Added following new actions 
   - Import FortiSOAR Template
-  - Export FortiSOAR Templates
+  - Export FortiSOAR Template


### PR DESCRIPTION
#### Changes:
- Added `Ignore Keys` parameter in `Export FortiSOAR Template` action.
- Fixed a bug where files were not being removed after playbook exection completed.

#### UTCs:
- [x] Tested and verified `Export FortiSOAR Template` action.
- [x] Tested and verified that all files created are being removed from tmp directory after playbook execution completed.
